### PR TITLE
fix issue with default typo3 v9 sitemap index

### DIFF
--- a/Classes/Command/CrawlSitemapCommand.php
+++ b/Classes/Command/CrawlSitemapCommand.php
@@ -135,7 +135,12 @@ class CrawlSitemapCommand extends Command
         $siteMap = json_decode(json_encode($xml), true) ?: [];
         if (($sites = $siteMap['sitemap']) || ($sites = $siteMap['url'])) {
             foreach ($sites as $site) {
-                if ($url = (string)$site['loc']) {
+                if(isset($site['loc'])){
+                    $url = (string)$site['loc'];
+                } else {
+                    $url = $site;
+                }
+                if (GeneralUtility::isValidUrl($url)) {
                     $params = GeneralUtility::explodeUrl2Array(parse_url($url)['query']);
                     if (array_key_exists('sitemap', $params) || (int)$params['type'] === 1533906435) {
                         $this->getUrlListFromSiteMap($url);


### PR DESCRIPTION
$sites will be an array containing two values if the sitemap is a sitemap index {url, tstamp}. In that case a warning exception at $site['loc'] "Warning: Illegal string offset 'loc'" is thrown.
So we set $url = $site (if we dont have $site['loc') ]and make an additional check isValidUrl to only continue if the url is indeed valid and fetchable later.